### PR TITLE
solytics-internal-linking: Add internal linking between all blog articles on solytics.d

### DIFF
--- a/src/__tests__/relatedArticles.test.js
+++ b/src/__tests__/relatedArticles.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { blogPosts } from '../data/blogPosts.js'
+import { relationshipMap, getRelatedArticles } from '../data/articles.js'
+import RelatedArticles from '../components/RelatedArticles.vue'
+
+const allSlugs = blogPosts.map(p => p.slug)
+
+describe('relationshipMap', () => {
+  it('every blog post has at least 2 related articles', () => {
+    for (const slug of allSlugs) {
+      const related = relationshipMap[slug]
+      expect(related, `${slug} missing from relationshipMap`).toBeDefined()
+      expect(related.length, `${slug} has only ${related?.length} related`).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('no article links to itself', () => {
+    for (const [slug, related] of Object.entries(relationshipMap)) {
+      expect(related, `${slug} links to itself`).not.toContain(slug)
+    }
+  })
+
+  it('all slugs in relationships exist in blogPosts', () => {
+    for (const [slug, related] of Object.entries(relationshipMap)) {
+      expect(allSlugs, `key "${slug}" not in blogPosts`).toContain(slug)
+      for (const r of related) {
+        expect(allSlugs, `"${r}" (related to ${slug}) not in blogPosts`).toContain(r)
+      }
+    }
+  })
+})
+
+describe('getRelatedArticles', () => {
+  it('returns full blog post objects', () => {
+    const articles = getRelatedArticles('ki-buchhaltung')
+    expect(articles.length).toBeGreaterThanOrEqual(2)
+    for (const a of articles) {
+      expect(a).toHaveProperty('slug')
+      expect(a).toHaveProperty('title')
+      expect(a).toHaveProperty('excerpt')
+    }
+  })
+
+  it('returns empty array for unknown slug', () => {
+    expect(getRelatedArticles('nonexistent')).toEqual([])
+  })
+})
+
+describe('RelatedArticles component', () => {
+  it('renders related article cards', () => {
+    const wrapper = mount(RelatedArticles, {
+      props: { slug: 'ki-buchhaltung' },
+      global: {
+        stubs: { 'router-link': { template: '<a><slot /></a>', props: ['to'] } },
+      },
+    })
+    const cards = wrapper.findAll('a')
+    expect(cards.length).toBeGreaterThanOrEqual(2)
+    expect(wrapper.text()).toContain('Das könnte Sie auch interessieren')
+  })
+
+  it('renders nothing for unknown slug', () => {
+    const wrapper = mount(RelatedArticles, {
+      props: { slug: 'nonexistent' },
+      global: {
+        stubs: { 'router-link': { template: '<a><slot /></a>', props: ['to'] } },
+      },
+    })
+    expect(wrapper.find('section').exists()).toBe(false)
+  })
+})

--- a/src/components/RelatedArticles.vue
+++ b/src/components/RelatedArticles.vue
@@ -1,0 +1,38 @@
+<template>
+  <section v-if="articles.length" class="mt-16 pt-10 border-t border-surface-100 dark:border-surface-300">
+    <h2 class="text-xl font-semibold text-surface-900 dark:text-surface-950 mb-6">Das könnte Sie auch interessieren</h2>
+    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <router-link
+        v-for="article in articles"
+        :key="article.slug"
+        :to="`/blog/${article.slug}`"
+        class="block bg-white dark:bg-surface-200 rounded-[var(--radius-card)] p-6 shadow-[var(--shadow-card)] hover:shadow-[var(--shadow-card-hover)] transition-all duration-300 group no-underline"
+      >
+        <span class="inline-block text-xs font-medium uppercase tracking-wider text-primary-500 dark:text-primary-400 mb-2">
+          {{ article.category === 'e-rechnung' ? 'E-Rechnung' : 'KI-Automatisierung' }}
+        </span>
+        <h3 class="text-base font-semibold text-surface-900 dark:text-surface-950 mb-2 group-hover:text-primary-500 transition-colors">
+          {{ article.title }}
+        </h3>
+        <p class="text-sm text-surface-500 leading-relaxed line-clamp-2">{{ article.excerpt }}</p>
+        <span class="inline-flex items-center text-sm font-medium text-primary-500 dark:text-primary-400 mt-3 group-hover:gap-2 transition-all">
+          Weiterlesen
+          <svg class="w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+          </svg>
+        </span>
+      </router-link>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { getRelatedArticles } from '../data/articles.js'
+
+const props = defineProps({
+  slug: { type: String, required: true },
+})
+
+const articles = computed(() => getRelatedArticles(props.slug))
+</script>

--- a/src/data/articles.js
+++ b/src/data/articles.js
@@ -1,0 +1,105 @@
+import { blogPosts } from './blogPosts.js'
+
+/**
+ * Manual relationship map: slug → array of related slugs (2-3 per article).
+ * Primary: same category. Cross-category where thematically close.
+ */
+const relationshipMap = {
+  // === E-Rechnung ===
+  'xrechnung-pflicht-2027': [
+    'xrechnung-vs-zugferd',
+    'e-rechnung-erstellen-anleitung',
+    'e-rechnung-kleinunternehmer',
+  ],
+  'e-rechnung-software-vergleich-2026': [
+    'e-rechnung-erstellen-anleitung',
+    'xrechnung-vs-zugferd',
+    'e-rechnung-kleinunternehmer',
+  ],
+  'e-rechnung-handwerk': [
+    'xrechnung-pflicht-2027',
+    'e-rechnung-erstellen-anleitung',
+    'e-rechnung-fehler',
+  ],
+  'xrechnung-vs-zugferd': [
+    'xrechnung-pflicht-2027',
+    'en16931-branchenerweiterungen',
+    'xrechnung-implementieren',
+  ],
+  'en16931-branchenerweiterungen': [
+    'xrechnung-implementieren',
+    'xrechnung-vs-zugferd',
+    'e-rechnung-handwerk',
+  ],
+  'xrechnung-implementieren': [
+    'en16931-branchenerweiterungen',
+    'e-rechnung-fehler',
+    'xrechnung-vs-zugferd',
+  ],
+  'e-rechnung-kleinunternehmer': [
+    'xrechnung-pflicht-2027',
+    'e-rechnung-steuerberater',
+    'e-rechnung-erstellen-anleitung',
+  ],
+  'e-rechnung-steuerberater': [
+    'e-rechnung-kleinunternehmer',
+    'e-rechnung-fehler',
+    'e-rechnung-software-vergleich-2026',
+  ],
+  'e-rechnung-erstellen-anleitung': [
+    'e-rechnung-fehler',
+    'xrechnung-vs-zugferd',
+    'e-rechnung-software-vergleich-2026',
+  ],
+  'e-rechnung-fehler': [
+    'e-rechnung-erstellen-anleitung',
+    'e-rechnung-steuerberater',
+    'xrechnung-implementieren',
+  ],
+
+  // === KI-Automatisierung ===
+  'ki-agenten-fuer-unternehmen': [
+    'ki-agent-vs-chatbot',
+    'ki-automatisierung-kosten',
+    'gmbh-mit-ki-agenten-automatisiert',
+  ],
+  'digitalisierung-mittelstand-2026': [
+    'ki-automatisierung-kosten',
+    'ki-buchhaltung',
+    'ki-im-vertrieb',
+  ],
+  'ki-im-vertrieb': [
+    'ki-agenten-fuer-unternehmen',
+    'ki-automatisierung-kosten',
+    'digitalisierung-mittelstand-2026',
+  ],
+  'ki-automatisierung-kosten': [
+    'ki-agenten-fuer-unternehmen',
+    'digitalisierung-mittelstand-2026',
+    'ki-im-vertrieb',
+  ],
+  'ki-buchhaltung': [
+    'e-rechnung-fehler',
+    'ki-automatisierung-kosten',
+    'digitalisierung-mittelstand-2026',
+  ],
+  'ki-agent-vs-chatbot': [
+    'ki-agenten-fuer-unternehmen',
+    'gmbh-mit-ki-agenten-automatisiert',
+    'ki-automatisierung-kosten',
+  ],
+  'gmbh-mit-ki-agenten-automatisiert': [
+    'ki-agenten-fuer-unternehmen',
+    'ki-agent-vs-chatbot',
+    'ki-buchhaltung',
+  ],
+}
+
+export function getRelatedArticles(slug) {
+  const relatedSlugs = relationshipMap[slug] || []
+  return relatedSlugs
+    .map(s => blogPosts.find(p => p.slug === s))
+    .filter(Boolean)
+}
+
+export { relationshipMap }

--- a/src/pages/blog/DigitalisierungMittelstand2026.vue
+++ b/src/pages/blog/DigitalisierungMittelstand2026.vue
@@ -149,5 +149,10 @@
     <p>
       <router-link to="/ki-automatisierung" class="font-semibold text-primary-600 hover:text-primary-700">Erfahren Sie mehr über KI-Automatisierung bei Solytics</router-link> oder starten Sie direkt mit dem <router-link to="/ki-automatisierung/readiness-check" class="font-semibold text-primary-600 hover:text-primary-700">kostenlosen KI-Readiness-Check</router-link>.
     </p>
+    <RelatedArticles slug="digitalisierung-mittelstand-2026" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/EN16931Branchenerweiterungen.vue
+++ b/src/pages/blog/EN16931Branchenerweiterungen.vue
@@ -220,5 +220,10 @@
     <h2>Fazit: Extensions machen E-Rechnungen branchentauglich</h2>
     <p>EN 16931 ist das Fundament. Für branchenspezifische Anforderungen brauchen Sie Extensions nach CEN/TS 16931-5. Die gute Nachricht: Der Standard hat das von Anfang an vorgesehen. Extensions sind keine Hacks — sie sind der offizielle Erweiterungsmechanismus.</p>
     <p>Entscheidend ist die Wahl eines Systems, das Extensions als Konzept versteht und nicht nur als Freitext-Workaround. Strukturierte Erweiterungen ermöglichen automatische Validierung und Verarbeitung — genau das, was die E-Rechnungspflicht bezweckt.</p>
+    <RelatedArticles slug="en16931-branchenerweiterungen" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungErstellenAnleitung.vue
+++ b/src/pages/blog/ERechnungErstellenAnleitung.vue
@@ -215,5 +215,10 @@
     <p>
       E-Rechnungen zu erstellen ist kein Hexenwerk. Mit dem richtigen Format, vollständigen Pflichtfeldern und einer Validierung vor dem Versand sind Sie auf der sicheren Seite. Starten Sie jetzt mit einer Testrechnung — je früher Sie Routine aufbauen, desto entspannter wird die Umstellung.
     </p>
+    <RelatedArticles slug="e-rechnung-erstellen-anleitung" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungFehler.vue
+++ b/src/pages/blog/ERechnungFehler.vue
@@ -142,5 +142,10 @@
     <p>
       Sie wollen sichergehen, dass Ihre E-Rechnungen fehlerfrei sind? <router-link to="/e-rechnung">Solytics unterstützt Sie</router-link> bei Einrichtung, Validierung und Testbetrieb — damit Ihre erste echte E-Rechnung auf Anhieb durchgeht. Starten Sie mit dem <router-link to="/e-rechnung/pflicht-check">kostenlosen Pflicht-Check</router-link>.
     </p>
+    <RelatedArticles slug="e-rechnung-fehler" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungHandwerk.vue
+++ b/src/pages/blog/ERechnungHandwerk.vue
@@ -166,5 +166,10 @@
     <p>
       Die Technik ist ausgereift. Die Formate sind standardisiert. Was fehlt, ist in vielen Betrieben nur der erste Schritt. Machen Sie ihn jetzt.
     </p>
+    <RelatedArticles slug="e-rechnung-handwerk" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungKleinunternehmer.vue
+++ b/src/pages/blog/ERechnungKleinunternehmer.vue
@@ -266,5 +266,10 @@
     </ul>
 
     <p>Fangen Sie heute an: Richten Sie den Empfang ein, testen Sie eine ZUGFeRD-Rechnung, und wählen Sie bis 2027 Ihre Software. Dann sind Sie rechtzeitig bereit.</p>
+    <RelatedArticles slug="e-rechnung-kleinunternehmer" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungSoftwareVergleich2026.vue
+++ b/src/pages/blog/ERechnungSoftwareVergleich2026.vue
@@ -106,5 +106,10 @@
     <p>
       Die Wahl der richtigen E-Rechnung-Software hängt von Ihrer Unternehmensgröße, Ihrem Rechnungsvolumen und Ihrer bestehenden IT-Landschaft ab. Wer jetzt die richtige Lösung wählt, spart sich späteren Migrationsstress und profitiert sofort von effizienteren Prozessen.
     </p>
+    <RelatedArticles slug="e-rechnung-software-vergleich-2026" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/ERechnungSteuerberater.vue
+++ b/src/pages/blog/ERechnungSteuerberater.vue
@@ -164,5 +164,10 @@
     <p>
       Starten Sie jetzt mit der Mandantensegmentierung. Identifizieren Sie die dringendsten Fälle. Und bauen Sie ein strukturiertes Beratungsangebot auf — Ihre Mandanten werden es Ihnen danken.
     </p>
+    <RelatedArticles slug="e-rechnung-steuerberater" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/GmbhMitKiAgentenAutomatisiert.vue
+++ b/src/pages/blog/GmbhMitKiAgentenAutomatisiert.vue
@@ -146,5 +146,10 @@
     <p>
       <strong>Weiterlesen:</strong> <router-link to="/blog/ki-automatisierung-kosten" class="text-primary-600 hover:text-primary-700 underline">Was kostet KI-Automatisierung? Preise, ROI und Amortisation 2026</router-link>
     </p>
+    <RelatedArticles slug="gmbh-mit-ki-agenten-automatisiert" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/KiAgentVsChatbot.vue
+++ b/src/pages/blog/KiAgentVsChatbot.vue
@@ -186,5 +186,10 @@
     <p>
       Sie sind unsicher, welche Lösung zu Ihrem Unternehmen passt? Unser <router-link to="/ki-automatisierung/readiness-check">KI-Readiness-Check</router-link> hilft Ihnen in wenigen Minuten, Ihre Ausgangslage einzuschätzen und die nächsten Schritte zu planen.
     </p>
+    <RelatedArticles slug="ki-agent-vs-chatbot" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/KiAgentenFuerUnternehmen.vue
+++ b/src/pages/blog/KiAgentenFuerUnternehmen.vue
@@ -103,5 +103,10 @@
     <p>
       KI-Agenten sind produktionsreif und liefern messbaren Mehrwert. Unternehmen, die jetzt einsteigen, sichern sich einen erheblichen Wettbewerbsvorteil. Starten Sie mit einem konkreten, abgegrenzten Anwendungsfall. Messen Sie die Ergebnisse. Und skalieren Sie dann schrittweise.
     </p>
+    <RelatedArticles slug="ki-agenten-fuer-unternehmen" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/KiAutomatisierungKosten.vue
+++ b/src/pages/blog/KiAutomatisierungKosten.vue
@@ -202,5 +202,10 @@
     <p>
       <strong>Weiterlesen:</strong> <router-link to="/blog/ki-agenten-fuer-unternehmen" class="text-primary-600 hover:text-primary-700 underline">KI-Agenten für Unternehmen — Prozesse automatisieren mit intelligenter Software</router-link>
     </p>
+    <RelatedArticles slug="ki-automatisierung-kosten" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/KiBuchhaltung.vue
+++ b/src/pages/blog/KiBuchhaltung.vue
@@ -119,5 +119,10 @@
     <p>
       Der erste Schritt ist einfach: <a href="/ki-automatisierung">Erfahren Sie mehr über unsere KI-Automatisierungslösungen</a> oder machen Sie den <a href="/ki-automatisierung/readiness-check">KI-Readiness-Check</a>, um Ihr Automatisierungspotenzial zu ermitteln.
     </p>
+    <RelatedArticles slug="ki-buchhaltung" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/KiImVertrieb.vue
+++ b/src/pages/blog/KiImVertrieb.vue
@@ -138,5 +138,10 @@
       <router-link to="/blog/ki-agenten-fuer-unternehmen">KI-Agenten fuer Unternehmen</router-link> |
       <router-link to="/blog/ki-automatisierung-kosten">Was kostet KI-Automatisierung?</router-link>
     </p>
+    <RelatedArticles slug="ki-im-vertrieb" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/XRechnungImplementieren.vue
+++ b/src/pages/blog/XRechnungImplementieren.vue
@@ -468,5 +468,10 @@ if __name__ == "__main__":
       <li><strong>ZUGFeRD parallel einrichten:</strong> Viele B2B-Empfänger bevorzugen das Hybridformat.</li>
       <li><strong>Fristen beachten:</strong> Die E-Rechnungspflicht 2027 betrifft alle B2B-Unternehmen.</li>
     </ul>
+    <RelatedArticles slug="xrechnung-implementieren" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/XRechnungPflicht2027.vue
+++ b/src/pages/blog/XRechnungPflicht2027.vue
@@ -90,5 +90,10 @@
     <p>
       Die XRechnung-Pflicht 2027 kommt. Die Übergangsfristen sind klar definiert und die technischen Standards ausgereift. Unternehmen, die jetzt beginnen, vermeiden Stress, sparen langfristig Kosten und verschaffen sich einen Wettbewerbsvorteil.
     </p>
+    <RelatedArticles slug="xrechnung-pflicht-2027" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>

--- a/src/pages/blog/XRechnungVsZugferd.vue
+++ b/src/pages/blog/XRechnungVsZugferd.vue
@@ -147,5 +147,10 @@
       <li><strong>Beide zusammen</strong> decken alle Szenarien ab. Investieren Sie in ein System, das beides kann.</li>
     </ul>
     <p>Die Versandpflicht greift ab 1. Januar 2027. Wer sich jetzt für eine Lösung entscheidet, die beide Formate unterstützt, ist für B2G und B2B gleichermaßen aufgestellt.</p>
+    <RelatedArticles slug="xrechnung-vs-zugferd" />
   </article>
 </template>
+
+<script setup>
+import RelatedArticles from '../../components/RelatedArticles.vue'
+</script>


### PR DESCRIPTION
## Automated Agent Task

**Task:** solytics-internal-linking
**Agent:** claude
**Branch:** `agent/solytics-internal-linking-20260326-173024`

### Prompt
> Add internal linking between all blog articles on solytics.de.

## What to build

1. A `RelatedArticles.vue` component in `src/components/` that displays 2-3 related articles at the bottom of each blog post. Use Tailwind CSS, match existing design.

2. An `articles.js` data module in `src/data/` that defines relationships between articles (which articles are related to which). Use the existing `blogPosts.js` as reference for slugs and categories.

3. Add the `RelatedArticles` component to EVERY blog article in `src/pages/blog/*.vue` (all 16 articles).

4. Grouping logic:
   - Same category articles are primary candidates (e-rechnung ↔ e-rechnung, ki-automatisierung ↔ ki-automatisierung)
   - Cross-category linking for thematically close articles (e.g. "KI in der Buchhaltung" ↔ "E-Rechnung Fehler")
   - Each article should link to 2-3 related articles

5. Write unit tests in `src/__tests__/relatedArticles.test.js`:
   - Every article has at least 2 related articles
   - No article links to itself
   - All slugs in relationships exist in blogPosts.js
   - Component renders correctly

## Constraints

- DO NOT delete or modify any existing content, routes, or components
- DO NOT modify blogPosts.js except to add imports if needed
- DO NOT remove any existing files
- DO NOT change the router configuration
- Tests must pass: `npx vitest run`
- Use Vue 3 Composition API + Tailwind CSS