### PR TITLE
fix: dark mode text contrast in 5 components

### DIFF
--- a/src/components/SectionHeading.vue
+++ b/src/components/SectionHeading.vue
@@ -6,7 +6,7 @@
     <h2 class="text-3xl sm:text-4xl lg:text-5xl font-bold text-surface-900 dark:text-surface-950 tracking-tight">
       <slot />
     </h2>
-    <p v-if="$slots.description" class="mt-4 text-lg text-surface-500 dark:text-surface-500 leading-relaxed">
+    <p v-if="$slots.description" class="mt-4 text-lg text-surface-500 dark:text-surface-700 leading-relaxed">
       <slot name="description" />
     </p>
   </div>

--- a/src/components/SiteFooter.vue
+++ b/src/components/SiteFooter.vue
@@ -1,11 +1,11 @@
 <template>
-  <footer class="bg-surface-900 dark:bg-surface-100 text-surface-300 dark:text-surface-600">
+  <footer class="bg-surface-900 dark:bg-surface-100 text-surface-300 dark:text-surface-800">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div class="grid grid-cols-1 md:grid-cols-4 gap-10">
         <!-- Brand -->
         <div class="md:col-span-1">
           <div class="font-bold text-xl text-white dark:text-surface-950 mb-3">Solytics</div>
-          <p class="text-sm text-surface-400 dark:text-surface-500 leading-relaxed">
+          <p class="text-sm text-surface-400 dark:text-surface-700 leading-relaxed">
             E-Rechnung &amp; KI-Automatisierung.<br>
             Software made in Germany.
           </p>
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <div class="mt-12 pt-8 border-t border-surface-800 dark:border-surface-200 flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-surface-500">
+      <div class="mt-12 pt-8 border-t border-surface-800 dark:border-surface-200 flex flex-col sm:flex-row justify-between items-center gap-4 text-sm text-surface-500 dark:text-surface-700">
         <p>&copy; {{ new Date().getFullYear() }} Solytics GmbH. Alle Rechte vorbehalten.</p>
         <div class="flex gap-6">
           <router-link to="/impressum" class="hover:text-white dark:hover:text-surface-950 transition-colors">Impressum</router-link>

--- a/src/pages/Blog.vue
+++ b/src/pages/Blog.vue
@@ -25,7 +25,7 @@
             class="px-4 py-2 text-sm font-medium rounded-full transition-colors"
             :class="activeCategory === cat.value
               ? 'bg-primary-500 text-white'
-              : 'bg-white dark:bg-surface-200 text-surface-600 dark:text-surface-500 hover:bg-primary-50 dark:hover:bg-surface-300'">
+              : 'bg-white dark:bg-surface-200 text-surface-600 dark:text-surface-800 hover:bg-primary-50 dark:hover:bg-surface-300'">
             {{ cat.label }}
           </button>
         </div>
@@ -42,10 +42,10 @@
               <h2 class="text-lg font-bold text-surface-900 dark:text-surface-950 group-hover:text-primary-600 transition-colors leading-snug">
                 {{ post.title }}
               </h2>
-              <p class="mt-3 text-sm text-surface-500 leading-relaxed line-clamp-3">
+              <p class="mt-3 text-sm text-surface-500 dark:text-surface-700 leading-relaxed line-clamp-3">
                 {{ post.excerpt }}
               </p>
-              <div class="mt-4 flex items-center gap-4 text-xs text-surface-400">
+              <div class="mt-4 flex items-center gap-4 text-xs text-surface-400 dark:text-surface-600">
                 <span>{{ formatDate(post.date) }}</span>
                 <span>{{ post.readingTime }}</span>
               </div>

--- a/src/pages/Datenschutz.vue
+++ b/src/pages/Datenschutz.vue
@@ -4,7 +4,7 @@
       <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <h1 class="text-3xl font-bold text-surface-900 dark:text-surface-950 mb-8">Datenschutzerklärung</h1>
 
-        <div class="bg-white dark:bg-surface-200 rounded-[var(--radius-card)] p-8 shadow-[var(--shadow-card)] prose prose-surface dark:prose-invert max-w-none text-surface-700 dark:text-surface-700">
+        <div class="bg-white dark:bg-surface-200 rounded-[var(--radius-card)] p-8 shadow-[var(--shadow-card)] prose prose-surface dark:prose-invert max-w-none text-surface-700 dark:text-surface-800">
           <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-950">1. Verantwortlicher</h2>
           <p>
             Solytics GmbH<br>

--- a/src/pages/Impressum.vue
+++ b/src/pages/Impressum.vue
@@ -4,7 +4,7 @@
       <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <h1 class="text-3xl font-bold text-surface-900 dark:text-surface-950 mb-8">Impressum</h1>
 
-        <div class="bg-white dark:bg-surface-200 rounded-[var(--radius-card)] p-8 shadow-[var(--shadow-card)] space-y-6 text-surface-700 dark:text-surface-700">
+        <div class="bg-white dark:bg-surface-200 rounded-[var(--radius-card)] p-8 shadow-[var(--shadow-card)] space-y-6 text-surface-700 dark:text-surface-800">
           <div>
             <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-950 mb-2">Angaben gemäß § 5 TMG</h2>
             <p>


### PR DESCRIPTION
Fixes #25

## Changes

Bumped `dark:text-surface-*` utility values to achieve WCAG AA contrast ratios on the inverted (dark) surface color scale.

| Component | Before | After |
|---|---|---|
| `SiteFooter.vue` | `dark:text-surface-600` | `dark:text-surface-800` |
| `SiteFooter.vue` brand description | `dark:text-surface-500` | `dark:text-surface-700` |
| `SiteFooter.vue` bottom bar | no dark variant | `dark:text-surface-700` |
| `SectionHeading.vue` description | `dark:text-surface-500` | `dark:text-surface-700` |
| `Blog.vue` inactive filter button | `dark:text-surface-500` | `dark:text-surface-800` |
| `Blog.vue` post excerpt | no dark variant | `dark:text-surface-700` |
| `Blog.vue` post meta | no dark variant | `dark:text-surface-600` |
| `Datenschutz.vue` body text | `dark:text-surface-700` | `dark:text-surface-800` |
| `Impressum.vue` body text | `dark:text-surface-700` | `dark:text-surface-800` |

No structural changes. No files deleted.

## Test plan

- [ ] Toggle dark mode and verify footer text is clearly readable
- [ ] Check SectionHeading description text on dark section backgrounds
- [ ] Verify Blog filter buttons and post card text in dark mode
- [ ] Confirm Datenschutz and Impressum body text is readable in dark mode